### PR TITLE
Fix keep-sorted installation path in GitHub Actions

### DIFF
--- a/.github/workflows/keep-sorted.yml
+++ b/.github/workflows/keep-sorted.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install keep-sorted
         run: |
-          go install github.com/google/keep-sorted/cmd/keep-sorted@latest
+          go install github.com/google/keep-sorted@latest
 
       - name: Run keep-sorted
         run: |


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions workflow error when installing keep-sorted.

## Problem
The workflow was failing with this error:
```
module github.com/google/keep-sorted@latest found (v0.7.1), but does not contain package github.com/google/keep-sorted/cmd/keep-sorted
```

## Solution
Updated the installation command from:
```bash
go install github.com/google/keep-sorted/cmd/keep-sorted@latest
```

To:
```bash
go install github.com/google/keep-sorted@latest
```

The correct module path is just `github.com/google/keep-sorted` without the `/cmd/keep-sorted` suffix.

## Testing
- The workflow should now successfully install keep-sorted
- The binary will be available at `~/go/bin/keep-sorted` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)